### PR TITLE
my ability card fix

### DIFF
--- a/jsons/TileResources.json
+++ b/jsons/TileResources.json
@@ -225,19 +225,19 @@
 	{
 		"name": "Ability Card; Yin-Yang Orb",
 		"resourceType": "Luxury",
-		"uniques": ["Not shown on world screen","[+8]% Strength <for [All] units>","Comment [Cards only give 1 [Happiness] as a luxury resource.]", "Comment [-4 [Happiness] to this resource]", "[-4 Happiness] <hidden from users>","Excluded from map editor"]
+		"uniques": ["Not shown on world screen","[+10]% Strength <for [All] units>","Comment [Cards only give 1 [Happiness] as a luxury resource.]", "Comment [-4 [Happiness] to this resource]", "[-4 Happiness] <hidden from users>","Excluded from map editor"]
 	},
 	{
 		"name": "Ability Card; Mini-Hakkero",
 		"resourceType": "Luxury",
-		"uniques": ["Not shown on world screen","[+12]% Strength <for [Siege] units>","Comment [Cards only give 1 [Happiness] as a luxury resource.]", "Comment [-4 [Happiness] to this resource]", "[-4 Happiness] <hidden from users>","Excluded from map editor"]
+		"uniques": ["Not shown on world screen","[+20]% Strength <for [Siege] units>","[+20]% Strength <for [Esoterica Practitioner] units>","Comment [Cards only give 1 [Happiness] as a luxury resource.]", "Comment [-4 [Happiness] to this resource]", "[-4 Happiness] <hidden from users>","Excluded from map editor"]
 	},
 	{
 		"name": "Ability Card; Shanghai Doll",
 		"resourceType": "Luxury",
 		"uniques": ["Not shown on world screen",
-			"[1] free [Worker] units appear <hidden from users>",
-			"[Worker] units gain the [Doll Construct] promotion <hidden from users>",
+			"[1] free [Worker] units appear",
+			"[Worker] units gain the [Doll Construct] promotion",
 			"Comment [Cards only give 1 [Happiness] as a luxury resource.]", "Comment [-4 [Happiness] to this resource]", "[-4 Happiness] <hidden from users>",
 			"Excluded from map editor"
 		]
@@ -245,12 +245,19 @@
 	{
 		"name": "Ability Card; Backdoor",
 		"resourceType": "Luxury",
-		"uniques": ["Not shown on world screen","[+15]% Strength <when defending> <when adjacent to a [{Friendly} {Military}] unit> <for [Military] units>","Comment [Cards only give 1 [Happiness] as a luxury resource.]", "Comment [-4 [Happiness] to this resource]", "[-4 Happiness] <hidden from users>","Excluded from map editor"]
+		"uniques": ["Not shown on world screen","[+15]% Strength <when defending> <when adjacent to a [{Friendly} {Military}] unit> <for [Military] units>", // It will be OP with Honor tree.
+			"Comment [Cards only give 1 [Happiness] as a luxury resource.]", "Comment [-4 [Happiness] to this resource]", "[-4 Happiness] <hidden from users>","Excluded from map editor"]
 	},
 	{
 		"name": "Ability Card; Offerings To A Sacred Mountain",
 		"resourceType": "Luxury",
-		"uniques": ["Not shown on world screen","[+1 Gold] from [Mountain] tiles [in all cities]","[+1] Sight <for [Scout] units>","Comment [Cards only give 1 [Happiness] as a luxury resource.]", "Comment [-4 [Happiness] to this resource]", "[-4 Happiness] <hidden from users>","Excluded from map editor"]
+		"uniques": ["Not shown on world screen",
+			"[+1 Gold] from [Mountain] tiles [in all cities] <when above [49] [Faith]> <hidden from users>",
+			"[+1 Gold] from [Mountain] tiles [in all cities] <when above [99] [Faith]> <hidden from users>",
+			"[+1 Gold] from [Mountain] tiles [in all cities] <when above [149] [Faith]> <hidden from users>",
+			"[+1 Gold] from [Mountain] tiles [in all cities] <when above [199] [Faith]> <hidden from users>",
+			"Comment [+1 Gold from mountain per 50 Faith stocked, up to 4.]",
+			"Comment [Cards only give 1 [Happiness] as a luxury resource.]", "Comment [-4 [Happiness] to this resource]", "[-4 Happiness] <hidden from users>","Excluded from map editor"]
 	},
 	{
 		"name": "Ability Card; Sutra Of Dharmatic Power",
@@ -300,7 +307,7 @@
 	{
 		"name": "Ability Card; Beauty Of Destruction",
 		"resourceType": "Luxury",
-		"uniques": ["Not shown on world screen","[Siege] units gain the [Card - Beauty Of Destruction] promotion","[+20]% Strength <vs cities> <for [All] units>","Comment [Cards only give 1 [Happiness] as a luxury resource.]", "Comment [-4 [Happiness] to this resource]", "[-4 Happiness] <hidden from users>","Excluded from map editor"]
+		"uniques": ["Not shown on world screen","[Siege] units gain the [Card - Beauty Of Destruction] promotion","[+15]% Strength <vs cities> <for [All] units>","Comment [Cards only give 1 [Happiness] as a luxury resource.]", "Comment [-4 [Happiness] to this resource]", "[-4 Happiness] <hidden from users>","Excluded from map editor"]
 	},
 	{
 		"name": "Ability Card; Drunkenly Whimsical Ibuki Gourd",


### PR DESCRIPTION
Made Yin-Yang Orb and Mini-Hakkero a little stronger (because they were too weak compared to other unit enhancement cards).
also, made Mini-Hakkero work with Esoterica Practitioner, which works the same way as Siege units.